### PR TITLE
fix(DropdownDateField) issue with calculating AM/PM

### DIFF
--- a/src/Forms/DropdownDatetimeField.php
+++ b/src/Forms/DropdownDatetimeField.php
@@ -43,8 +43,15 @@ class DropdownDatetimeField extends DatetimeField {
             return null;
         }
 
-		$time = $value['time'];
-		$hours = ($time['Period'] == 'AM') ? $time['Hours'] : $time['Hours'] + 12;
+        $time = $value['time'];
+        $hours = '';
+
+        if ($time['Hours'] == 12) {
+            $hours = $time['Period'] == 'AM' ? '00' : '12';
+        } else {
+            $hours = ($time['Period'] == 'AM') ? $time['Hours'] : $time['Hours'] + 12;
+        }
+
 
 		$dateTime->setTime((int)$hours, (int)$time['Mins']);
 


### PR DESCRIPTION
If the user chose 12 PM as the time, the calculation would be done as 12 + 12, = 24, which flips the date over to 'tomorrow' and adding 12 hours every save. 